### PR TITLE
posts, episodesテーブルにtimestampを追加

### DIFF
--- a/apps/backend/prisma/migrations/20250206160428_add_timestamp/migration.sql
+++ b/apps/backend/prisma/migrations/20250206160428_add_timestamp/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - Added the required column `updated_at` to the `episodes` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updated_at` to the `posts` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "episodes" 
+ADD COLUMN "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN "updated_at" TIMESTAMP(3); -- 一旦デフォルト値なしで追加
+-- デフォルト値を設定するために一度更新
+UPDATE "episodes" SET "updated_at" = CURRENT_TIMESTAMP WHERE "updated_at" IS NULL;
+-- 更新後にNOT NULL制約を追加
+ALTER TABLE "episodes" ALTER COLUMN "updated_at" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "posts" 
+ADD COLUMN "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN "updated_at" TIMESTAMP(3); -- 一旦デフォルト値なしで追加
+
+-- デフォルト値を設定するために一度更新
+UPDATE "posts" SET "updated_at" = CURRENT_TIMESTAMP WHERE "updated_at" IS NULL;
+-- 更新後にNOT NULL制約を追加
+ALTER TABLE "posts" ALTER COLUMN "updated_at" SET NOT NULL;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -15,16 +15,20 @@ model Post {
   episodeId    Int?     @map("episode_id")
   episode      Episode? @relation("EpisodePosts", fields: [episodeId], references: [id])
   thumbnailFor Episode? @relation("ThumbnailPost")
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
 
   @@map("posts")
 }
 
 model Episode {
-  id              Int    @id @default(autoincrement())
-  title           String @unique
-  thumbnailPostId Int    @unique @map("thumbnail_post_id")
-  thumbnailPost   Post   @relation("ThumbnailPost", fields: [thumbnailPostId], references: [id])
-  posts           Post[] @relation("EpisodePosts")
+  id              Int      @id @default(autoincrement())
+  title           String   @unique
+  thumbnailPostId Int      @unique @map("thumbnail_post_id")
+  thumbnailPost   Post     @relation("ThumbnailPost", fields: [thumbnailPostId], references: [id])
+  posts           Post[]   @relation("EpisodePosts")
+  createdAt       DateTime @default(now()) @map("created_at")
+  updatedAt       DateTime @updatedAt @map("updated_at")
 
   @@map("episodes")
 }


### PR DESCRIPTION
updated_at(デフォルト値なし)をnot nullで追加するためにマイグレーションファイルを手動で修正した