### PR TITLE
エピソードカードのwidthをPostGalleryと一致させてみる

### DIFF
--- a/packages/ui/src/components/Episodes/EpisodeCard.tsx
+++ b/packages/ui/src/components/Episodes/EpisodeCard.tsx
@@ -30,7 +30,7 @@ export function EpisodeCard({
         <NextImage
           src={episode.thumbnailPost.filename}
           alt={episode.title}
-          width={350}
+          width={400}
           styleWidth={imageWidth}
           priority
         />


### PR DESCRIPTION
- エピソード詳細を開くと、サムネ画像が新しく読み込まれるから別画像扱いになってる？ 改善したい