### PR TITLE
語録登録画面を開くとエラーになる不具合を解消

### DIFF
--- a/apps/admin/src/features/Tags/components/PopularWordForm.tsx
+++ b/apps/admin/src/features/Tags/components/PopularWordForm.tsx
@@ -106,7 +106,7 @@ type CharacterSelectorProps = {
 /** キャラセレクターコンポーネント */
 function CharacterSelector({ characters, selectedId, onValueChange }: CharacterSelectorProps) {
   const charactersSelection = createListCollection({
-    items: characters,
+    items: characters ?? [], // なぜかnullかundefinedっぽいエラーが出るので、空配列をデフォルト値にする
     itemToString: (item: CharacterEntity) => item.name,
     itemToValue: (item: CharacterEntity) => item.id.toString(),
   });


### PR DESCRIPTION
- セレクタコンポーネントのデータを用意する部分でitemsにnullかundefinedが来てるようなエラーで落ちる