### PR TITLE
adminのPost詳細404を解消

### DIFF
--- a/apps/backend/src/modules/popular_words/popular_words.service.ts
+++ b/apps/backend/src/modules/popular_words/popular_words.service.ts
@@ -30,10 +30,10 @@ export class PopularWordsService {
         word: true,
         kana: true,
       },
-      orderBy: {
-        kana: 'asc',
-        id: 'asc',
-      },
+      orderBy: [
+        { kana: 'asc' },
+        { id: 'asc' },
+      ],
     });
 
     return {


### PR DESCRIPTION
- wordが同じ語録用にidを第2ソートキーとして設定したものの、指定の仕方が違ってエラーになっていた
- これのせいでSSGが失敗していた