### PR TITLE
Postに紐づけされてない各タグの詳細ページ表示がエラーになる不具合に対応する

### DIFF
--- a/apps/backend/src/modules/characters/characters.controller.ts
+++ b/apps/backend/src/modules/characters/characters.controller.ts
@@ -24,6 +24,13 @@ export class CharactersController {
     return this.charactersService.findAllCharacters();
   }
 
+  @Get('/find-all-characters-have-some-posts')
+  async findAllCharactersHaveSomePosts(): Promise<FindAllCharactersResponse> {
+    this.logger.log('findAllCharactersHaveSomePosts');
+
+    return this.charactersService.findAllCharacters(false);
+  }
+
   @Get('/get-characters-post-count')
   async getCharactersPostCount(): Promise<GetCharactersPostCountResponse> {
     this.logger.log('getCharactersPostCount');

--- a/apps/backend/src/modules/characters/characters.service.ts
+++ b/apps/backend/src/modules/characters/characters.service.ts
@@ -32,7 +32,7 @@ export class CharactersService {
     });
   }
 
-  async findAllCharacters(): Promise<FindAllCharactersResponse> {
+  async findAllCharacters(all: boolean = true): Promise<FindAllCharactersResponse> {
     const characters = await this.prisma.character.findMany({
       select: {
         id: true,
@@ -40,6 +40,14 @@ export class CharactersService {
         nameKey: true,
         iconFilename: true,
       },
+      where: all
+        ? {}
+        : {
+          // Postがないキャラクターを除外
+          posts: {
+            some: {},
+          },
+        },
       orderBy: {
         order: 'asc',
       },

--- a/apps/backend/src/modules/popular_words/popular_words.controller.ts
+++ b/apps/backend/src/modules/popular_words/popular_words.controller.ts
@@ -34,6 +34,13 @@ export class PopularWordsController {
     return this.popularWordsService.findAllPopularWordSpeakers();
   }
 
+  @Get('/find-all-popular-word-speakers-have-some-posts')
+  async findAllPopularWordSpeakersHaveSomePosts(): Promise<FindAllPopularWordSpeakersResponse> {
+    this.logger.log('findAllPopularWordSpeakersHaveSomePosts');
+
+    return this.popularWordsService.findAllPopularWordSpeakers(false);
+  }
+
   @Get('/get-popular-words-post-count')
   async getPopularWordsPostCount(): Promise<GetPopularWordsPostCountResponse> {
     this.logger.log('getPopularWordsPostCount');

--- a/apps/backend/src/modules/popular_words/popular_words.service.ts
+++ b/apps/backend/src/modules/popular_words/popular_words.service.ts
@@ -41,7 +41,7 @@ export class PopularWordsService {
     };
   }
 
-  async findAllPopularWordSpeakers(): Promise<FindAllPopularWordSpeakersResponse> {
+  async findAllPopularWordSpeakers(all: boolean = true): Promise<FindAllPopularWordSpeakersResponse> {
     // まず発言者情報も含めて全ての語録を取得
     const allPopularWords = await this.prisma.popularWord.findMany({
       select: {
@@ -57,6 +57,14 @@ export class PopularWordsService {
           },
         },
       },
+      where: all
+        ? {}
+        : {
+          // Postがない語録を除外
+          posts: {
+            some: {},
+          },
+        },
       orderBy: [
         {
           speaker: {

--- a/apps/backend/src/modules/tags/tags.controller.ts
+++ b/apps/backend/src/modules/tags/tags.controller.ts
@@ -27,6 +27,13 @@ export class TagsController {
     return this.tagsService.findAllTags();
   }
 
+  @Get('/find-all-tags-have-some-posts')
+  async findAllTagsHaveSomePosts(): Promise<FindAllTagsResponse> {
+    this.logger.log('findAllTagsHaveSomePosts started');
+
+    return this.tagsService.findAllTags(false);
+  }
+
   @Get('/get-tags-post-count')
   async getTagsPostCount(): Promise<GetTagsPostCountResponse> {
     this.logger.log('getTagsPostCount');

--- a/apps/backend/src/modules/tags/tags.service.ts
+++ b/apps/backend/src/modules/tags/tags.service.ts
@@ -14,12 +14,20 @@ export class TagsService {
 
   private readonly logger = new Logger(TagsService.name);
 
-  async findAllTags(): Promise<FindAllTagsResponse> {
+  async findAllTags(all: boolean = true): Promise<FindAllTagsResponse> {
     const tags = await this.prisma.tag.findMany({
       select: {
         id: true,
         name: true,
       },
+      where: all
+        ? {}
+        : {
+          // Postがないタグを除外
+          posts: {
+            some: {},
+          },
+        },
       orderBy: {
         kana: 'asc',
       },

--- a/apps/frontend/src/features/Tags/api/tags-api.ts
+++ b/apps/frontend/src/features/Tags/api/tags-api.ts
@@ -25,9 +25,18 @@ export class TagsApi {
 
   private tagsApiBase = tagsApiBase;
 
-  /** キャラクター一覧を取得する */
-  async findAllCharacters(): Promise<FindAllCharactersResponse> {
-    return await this.tagsApiBase.findAllCharacters();
+  /** Postを持つキャラクター一覧を取得する */
+  async findAllCharactersHaveSomePosts(): Promise<FindAllCharactersResponse> {
+    const url = `${this.endpointCharacters}/find-all-characters-have-some-posts`;
+
+    const res = await fetchData(url);
+
+    if (!res.ok) {
+      throw new Error('キャラクター一覧取得処理に失敗しました。');
+    }
+
+    const data = await res.json();
+    return data;
   }
 
   /** キャラクターごとのPost数を取得する */
@@ -60,9 +69,18 @@ export class TagsApi {
     return data;
   }
 
-  /** タグ一覧を取得する */
-  async findAllTags(): Promise<FindAllTagsResponse> {
-    return await this.tagsApiBase.findAllTags();
+  /** Postを持つタグ一覧を取得する */
+  async findAllTagsHaveSomePosts(): Promise<FindAllTagsResponse> {
+    const url = `${this.endpointTags}/find-all-tags-have-some-posts`;
+
+    const res = await fetchData(url);
+
+    if (!res.ok) {
+      throw new Error('タグ一覧取得処理に失敗しました。');
+    }
+
+    const data = await res.json();
+    return data;
   }
 
   /** タグごとのPost数を取得する */
@@ -95,9 +113,18 @@ export class TagsApi {
     return data;
   }
 
-  /** 語録一覧を取得する */
-  async findAllPopularWordSpeakers(): Promise<FindAllPopularWordSpeakersResponse> {
-    return await this.tagsApiBase.findAllPopularWordSpeakers();
+  /** Postを持つ語録一覧を取得する */
+  async findAllPopularWordSpeakersHaveSomePosts(): Promise<FindAllPopularWordSpeakersResponse> {
+    const url = `${this.endpointPopularWords}/find-all-popular-word-speakers-have-some-posts`;
+
+    const res = await fetchData(url);
+
+    if (!res.ok) {
+      throw new Error('語録一覧取得処理に失敗しました。');
+    }
+
+    const data = await res.json();
+    return data;
   }
 
   /** 語録ごとのPost数を取得する */

--- a/apps/frontend/src/pages/tags/index.tsx
+++ b/apps/frontend/src/pages/tags/index.tsx
@@ -7,11 +7,11 @@ import { TagsProps } from '@/features/Tags/types/tags-types';
 export const getStaticProps: GetStaticProps<TagsProps> = async () => {
   try {
     // キャラクター一覧をAPIから取得
-    const { characters } = await tagsApi.findAllCharacters();
+    const { characters } = await tagsApi.findAllCharactersHaveSomePosts();
     // タグ一覧をAPIから取得
-    const { tags } = await tagsApi.findAllTags();
+    const { tags } = await tagsApi.findAllTagsHaveSomePosts();
     // 語録一覧をAPIから取得
-    const { popularWordSpeakers } = await tagsApi.findAllPopularWordSpeakers();
+    const { popularWordSpeakers } = await tagsApi.findAllPopularWordSpeakersHaveSomePosts();
 
     // ページコンポーネントに渡すpropsを返す
     return {


### PR DESCRIPTION
- そもそもPostを持たないタグは表示しないようにすることで対応
- 一覧取得APIはadminと共用しているので専用のものを作成
- ちなみにSSG生成処理でデータが空のとき404にする対応は意味がなかった
- /tag/[id]/page/1 ではなく /tag/[id] を経由してリダイレクトする対応では404が表示されるようになったが、戻るボタンで戻れなくなるのでやめた