### PR TITLE
急にPWAインストールできなくなった問題に対応

### DIFF
--- a/apps/admin/src/middleware.ts
+++ b/apps/admin/src/middleware.ts
@@ -18,6 +18,6 @@ export async function middleware(request: NextRequest) {
 // このミドルウェアから除外するパスを指定
 export const config = {
   matcher: [
-    '/((?!api|_next/static|_next/image|favicon.ico|manifest.json|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!api|_next/static|_next/image|favicon.ico|manifest.json|sw.js|workbox-*.js|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 };

--- a/apps/admin/src/middleware.ts
+++ b/apps/admin/src/middleware.ts
@@ -15,9 +15,9 @@ export async function middleware(request: NextRequest) {
   return await supabaseSessionMiddleware(request, options);
 }
 
-// このミドルウェアを適用するパス
+// このミドルウェアから除外するパスを指定
 export const config = {
   matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!api|_next/static|_next/image|favicon.ico|manifest.json|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 };

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -23,6 +23,6 @@ export async function middleware(request: NextRequest) {
 // このミドルウェアから除外するパスを指定
 export const config = {
   matcher: [
-    '/((?!api|_next/static|_next/image|favicon.ico|manifest.json|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!api|_next/static|_next/image|favicon.ico|manifest.json|sw.js|workbox-*.js|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 };

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -20,9 +20,9 @@ export async function middleware(request: NextRequest) {
   return await supabaseSessionMiddleware(request, options);
 }
 
-// このミドルウェアを適用するパス
+// このミドルウェアから除外するパスを指定
 export const config = {
   matcher: [
-    '/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/((?!api|_next/static|_next/image|favicon.ico|manifest.json|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],
 };


### PR DESCRIPTION
- 未ログイン状態だと認証ミドルウェアによってmanifest.jsonの読み込みに失敗しswの登録ができていなかった