### PR TITLE
お気に入り一覧が1ページ12枚固定になりページネーションできない不具合を修正する

### DIFF
--- a/apps/backend/src/modules/users/users.controller.ts
+++ b/apps/backend/src/modules/users/users.controller.ts
@@ -12,17 +12,10 @@ export class UsersController {
   @Get('/get-user-favs')
   async getUserFavs(
     @Headers('authorization') token: string,
-    @Query('limit') limit?: number,
-    @Query('offset') offset?: number,
-    @Query('sort') sort?: 'asc' | 'desc',
   ) {
     this.logger.log('getUserFavs');
 
-    return this.usersService.getUserFavs(token, {
-      limit: limit ? Number(limit) : undefined,
-      offset: offset ? Number(offset) : undefined,
-      sort,
-    });
+    return this.usersService.getUserFavs(token);
   }
 
   @Post('/toggle-user-favs')

--- a/apps/backend/src/modules/users/users.service.ts
+++ b/apps/backend/src/modules/users/users.service.ts
@@ -18,15 +18,13 @@ export class UsersService {
 
   private readonly logger = new Logger(UsersService.name);
 
-  async getUserFavs(token: string, query: PaginationParams): Promise<GetUserFavsResponse> {
+  async getUserFavs(token: string): Promise<GetUserFavsResponse> {
     // トークン検証してユーザー取得
     const user = await this.supabase.getUser(token);
 
     if (!user) {
       throw new Error('ユーザ取得に失敗しました😨');
     }
-
-    const { limit = 12, offset = 0, sort = 'desc' } = query;
 
     // 全体の件数を取得
     const total = await this.prisma.userFav.count({
@@ -52,10 +50,8 @@ export class UsersService {
         },
       },
       orderBy: {
-        favedAt: sort,
+        favedAt: 'desc',
       },
-      take: limit,
-      skip: offset,
     });
 
     const posts = favorites.map((fav) => fav.post);


### PR DESCRIPTION
- APIを他のSSGページネーション画面と同様のインターフェースにしていた(全データを取得して擬似的にページネーションしているのでlimitやoffsetは不要)